### PR TITLE
Fix : Environment Description Faliure

### DIFF
--- a/android/src/main/kotlin/com/sanzaaltech/esewa_client/EsewaClientPlugin.kt
+++ b/android/src/main/kotlin/com/sanzaaltech/esewa_client/EsewaClientPlugin.kt
@@ -68,12 +68,13 @@ class EsewaClientPlugin : FlutterPlugin, MethodCallHandler, ActivityAware, Plugi
     val secretKey: String = message["secret_key"] as String
     val payment: HashMap<String, Any> = message["payment"] as HashMap<String, Any>
     val environment: String = message["environment"] as String
+    var env : ESewaConfiguration = if(environment == "TEST") ESewaConfiguration.ENVIRONMENT_TEST else ESewaConfiguration.ENVIRONMENT_LIVE
 
     // create esewa configuration variable
     val eSewaConfiguration: ESewaConfiguration = ESewaConfiguration()
       .clientId(clientId)
       .secretKey(secretKey)
-      .environment(environment.toLowerCase())
+      .environment(env)
 
     // create esewa payment intent
     val eSewaPayment = ESewaPayment(payment["amount"] as String, payment["product_name"] as String, payment["product_id"] as String, payment["callback_url"] as String)

--- a/android/src/main/kotlin/com/sanzaaltech/esewa_client/EsewaClientPlugin.kt
+++ b/android/src/main/kotlin/com/sanzaaltech/esewa_client/EsewaClientPlugin.kt
@@ -68,7 +68,7 @@ class EsewaClientPlugin : FlutterPlugin, MethodCallHandler, ActivityAware, Plugi
     val secretKey: String = message["secret_key"] as String
     val payment: HashMap<String, Any> = message["payment"] as HashMap<String, Any>
     val environment: String = message["environment"] as String
-    var env : String = if(environment == "TEST") ESewaConfiguration.ENVIRONMENT_TEST else ESewaConfiguration.ENVIRONMENT_LIVE
+    var env = if(environment == "TEST") ESewaConfiguration.ENVIRONMENT_TEST else ESewaConfiguration.ENVIRONMENT_LIVE
 
     // create esewa configuration variable
     val eSewaConfiguration: ESewaConfiguration = ESewaConfiguration()

--- a/android/src/main/kotlin/com/sanzaaltech/esewa_client/EsewaClientPlugin.kt
+++ b/android/src/main/kotlin/com/sanzaaltech/esewa_client/EsewaClientPlugin.kt
@@ -68,7 +68,7 @@ class EsewaClientPlugin : FlutterPlugin, MethodCallHandler, ActivityAware, Plugi
     val secretKey: String = message["secret_key"] as String
     val payment: HashMap<String, Any> = message["payment"] as HashMap<String, Any>
     val environment: String = message["environment"] as String
-    var env : ESewaConfiguration = if(environment == "TEST") ESewaConfiguration.ENVIRONMENT_TEST else ESewaConfiguration.ENVIRONMENT_LIVE
+    var env : String = if(environment == "TEST") ESewaConfiguration.ENVIRONMENT_TEST else ESewaConfiguration.ENVIRONMENT_LIVE
 
     // create esewa configuration variable
     val eSewaConfiguration: ESewaConfiguration = ESewaConfiguration()


### PR DESCRIPTION
I noticed that the way environment was being sent to the ESEWA plugin was with a string that we pass from the dart code which can be dangerous if ESEWA SDK decides to change the value of Their variables ESewaConfiguration.ENVIRONMENT_TEST or ESewaConfiguration.ENVIRONMENT_PRODUCTION so I came up with a simple fix.